### PR TITLE
checkstyle task will fail build is issues are found

### DIFF
--- a/configs/style-checks.xml
+++ b/configs/style-checks.xml
@@ -39,7 +39,7 @@
 <module name="Checker">
     <property name="charset" value="UTF-8" />
 
-    <property name="severity" value="warning" />
+    <property name="severity" value="error" />
 
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->

--- a/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
+++ b/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
@@ -537,7 +537,7 @@ public abstract class LiRestClient {
      */
     private static class RefreshAndRetryInterceptor implements Interceptor {
 
-        private static int MAX_TRIES = 2;
+        private static final int MAX_TRIES = 2;
 
         private WeakReference<Context> context;
         private LiSDKManager sdk;


### PR DESCRIPTION
If style issues are found during build instead of simply logging warnings in the console the build will now fail with an error. The style issues will be listed in the console output. e.g.

```
> Task :lia-core:checkstyle FAILED
[ant:checkstyle] [ERROR] [redacted]/lia-sdk-android/lia-core/src/main/java/com/lithium/community/android/queryutil/LiQueryRequestParams.java:127:20: WhitespaceAround: 'for' is not followed by whitespace. [WhitespaceAround]
[ant:checkstyle] [ERROR] [redacted]/lia-sdk-android/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java:540:28: Member name 'MAX_TRIES' must match pattern '^[a-z][a-zA-Z0-9]*$'. [StaticVariableName]
```