### PR TITLE
MOB-511 Changes in string names

### DIFF
--- a/lia-demo/src/dev/java/com/lithium/community/android/example/InitializationActivity.java
+++ b/lia-demo/src/dev/java/com/lithium/community/android/example/InitializationActivity.java
@@ -182,11 +182,11 @@ public class InitializationActivity extends AppCompatActivity {
 
         void reset() {
             // TODO: use credentials from shared preferences if available
-            clientName = MiscUtils.sanitize(getString(R.string.clientName));
-            clientId = MiscUtils.sanitize(getString(R.string.clientId));
-            clientSecret = MiscUtils.sanitize(getString(R.string.clientSecret));
-            tenantId = MiscUtils.sanitize(getString(R.string.tenantId));
-            communityUrl = MiscUtils.sanitize(getString(R.string.communityUrl));
+            clientName = MiscUtils.sanitize(getString(R.string.li_client_name));
+            clientId = MiscUtils.sanitize(getString(R.string.li_client_id));
+            clientSecret = MiscUtils.sanitize(getString(R.string.li_client_secret));
+            tenantId = MiscUtils.sanitize(getString(R.string.li_tenant_id));
+            communityUrl = MiscUtils.sanitize(getString(R.string.li_community_url));
         }
 
         boolean areCredentialsProvided() {

--- a/lia-demo/src/main/java/com/lithium/community/android/example/MainApplication.java
+++ b/lia-demo/src/main/java/com/lithium/community/android/example/MainApplication.java
@@ -33,11 +33,11 @@ public class MainApplication extends Application {
         try {
             if (MiscUtils.areCredentialsProvided(this)) {
                 LiAppCredentials credentials = new LiAppCredentials(
-                        getString(R.string.clientName),
-                        getString(R.string.clientId),
-                        getString(R.string.clientSecret),
-                        getString(R.string.tenantId),
-                        getString(R.string.communityUrl),
+                        getString(R.string.li_client_name),
+                        getString(R.string.li_client_id),
+                        getString(R.string.li_client_secret),
+                        getString(R.string.li_tenant_id),
+                        getString(R.string.li_community_url),
                         MiscUtils.getInstanceId(this)
                 );
                 LiSDKManager.initialize(this, credentials);

--- a/lia-demo/src/main/java/com/lithium/community/android/example/utils/MiscUtils.java
+++ b/lia-demo/src/main/java/com/lithium/community/android/example/utils/MiscUtils.java
@@ -38,11 +38,11 @@ public class MiscUtils {
         boolean result = true;
         String undefined = context.getString(R.string.undefined);
         String[] properties = new String[]{
-                context.getString(R.string.clientName),
-                context.getString(R.string.clientId),
-                context.getString(R.string.clientSecret),
-                context.getString(R.string.tenantId),
-                context.getString(R.string.communityUrl)
+                context.getString(R.string.li_client_name),
+                context.getString(R.string.li_client_id),
+                context.getString(R.string.li_client_secret),
+                context.getString(R.string.li_tenant_id),
+                context.getString(R.string.li_community_url)
         };
 
         for (String property : properties) {

--- a/lia-demo/src/main/res/values/credentials.xml
+++ b/lia-demo/src/main/res/values/credentials.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="clientId"><!--PLEASE ADD THE CLIENT ID HERE--></string>
-    <string name="clientSecret"><!--PLEASE ADD THE CLIENT SECRET HERE--></string>
-    <string name="clientName"><!--PLEASE ADD THE CLIENT NAME HERE--></string>
-    <string name="tenantId"><!--PLEASE ADD THE CLIENT TENANT ID HERE--></string>
-    <string name="communityUrl"><!--PLEASE ADD THE COMMUNITY BASE URL HERE--></string>
+    <string name="li_client_id"><!--PLEASE ADD THE CLIENT ID HERE--></string>
+    <string name="li_client_secret"><!--PLEASE ADD THE CLIENT SECRET HERE--></string>
+    <string name="li_community_url"><!--PLEASE ADD THE COMMUNITY BASE URL HERE--></string>
+    <string name="li_tenant_id"><!--PLEASE ADD THE CLIENT TENANT ID HERE--></string>
+    <string name="li_client_name"><!--PLEASE ADD THE CLIENT NAME HERE--></string>
 </resources>


### PR DESCRIPTION
The previous naming was not in android xml entity naming convention, also it could coincide with other services which would also have client-id and client-secret. 
Hence changing the camelCase naming to android naming also adding a prefix 'li_' to differentiate our client parameters. 