### PR TITLE
Mob 273

### DIFF
--- a/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
+++ b/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
@@ -564,6 +564,8 @@ public abstract class LiRestClient {
                 } else if (response.code() != HTTP_CODE_SUCCESSFUL && response.code() != HttpURLConnection.HTTP_CREATED) {
 
                     try {
+                        int httpCode = response.code();
+                        String responseStr = response.body().string();
                         synchronized (this) {
                             Thread.sleep((long) (Math.pow(2, currentCount - 1) * 2000));
                             // first time reaching this point, currentCount will always be 1, hence currentCount-1.
@@ -572,9 +574,6 @@ public abstract class LiRestClient {
                             // third time it waits for 2^2 = 8 seconds
                             // next time perhaps!, God help.
                         }
-
-                        int httpCode = response.code();
-                        String responseStr = response.body().string();
 
                         try {
                             JsonObject data = new Gson().fromJson(responseStr, JsonObject.class);

--- a/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
+++ b/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
@@ -560,7 +560,7 @@ public abstract class LiRestClient {
 
                 if (response == null) {
                     proceed = true;
-                } else if (response.code() != HTTP_CODE_SUCCESSFUL || response.code() != HttpURLConnection.HTTP_CREATED) {
+                } else if (response.code() != HTTP_CODE_SUCCESSFUL && response.code() != HttpURLConnection.HTTP_CREATED) {
 
                     try {
                         synchronized (this) {

--- a/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
+++ b/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
@@ -577,8 +577,8 @@ public abstract class LiRestClient {
 
                         try {
                             JsonObject data = new Gson().fromJson(responseStr, JsonObject.class);
-                            if (data != null && data.has("statusCode")) {
-                                httpCode = data.get("statusCode").getAsInt();
+                            if (data != null && data.has("http_code")) {
+                                httpCode = data.get("http_code").getAsInt();
                             }
                         } catch (JsonSyntaxException ex) {
                             Log.e(LI_LOG_TAG, "wrong json, not able to parse " + ex.getMessage());

--- a/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
+++ b/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
@@ -51,6 +51,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.Map;
@@ -537,7 +538,7 @@ public abstract class LiRestClient {
      */
     private static class RefreshAndRetryInterceptor implements Interceptor {
 
-        private static final int MAX_TRIES = 2;
+        private static final int MAX_TRIES = 4; // One actual call + 3 trials
 
         private WeakReference<Context> context;
         private LiSDKManager sdk;
@@ -553,43 +554,90 @@ public abstract class LiRestClient {
             int currentCount = 0;
             Response response = null;
 
-            while (currentCount < MAX_TRIES && (response == null || (response.code() != HTTP_CODE_SUCCESSFUL))) {
+            while (currentCount < MAX_TRIES
+                    && (response == null || ((response.code() != HTTP_CODE_SUCCESSFUL) && (response.code() != HttpURLConnection.HTTP_CREATED)))) {
                 boolean proceed = false;
 
                 if (response == null) {
                     proceed = true;
-                } else if (response.code() != HTTP_CODE_SUCCESSFUL) {
-                    int httpCode = response.code();
-                    JsonObject data;
-                    String responseStr = response.body().string();
+                } else if (response.code() != HTTP_CODE_SUCCESSFUL || response.code() != HttpURLConnection.HTTP_CREATED) {
 
                     try {
-                        data = new Gson().fromJson(responseStr, JsonObject.class);
-                        if (data != null && data.has("statusCode")) {
-                            httpCode = data.get("statusCode").getAsInt();
+                        synchronized (this) {
+                            Thread.sleep((long) (Math.pow(2, currentCount - 1) * 2000));
+                            // first time reaching this point, currentCount will always be 1, hence currentCount-1.
+                            // so first time it waits for 2^0 = 2 seconds
+                            // second time it waits for 2^1 = 4 seconds
+                            // third time it waits for 2^2 = 8 seconds
+                            // next time perhaps!, God help.
                         }
-                    } catch (JsonSyntaxException ex) {
-                        Log.e(LI_LOG_TAG, "wrong json, not able to parse " + ex.getMessage());
-                    }
 
-                    if (httpCode == HTTP_CODE_UNAUTHORIZED || httpCode == HTTP_CODE_FORBIDDEN) {
+                        int httpCode = response.code();
+                        String responseStr = response.body().string();
+
                         try {
-                            Context context = this.context.get();
-                            if (context != null) {
-                                LiTokenResponse liTokenResponse = new LiAuthServiceImpl(context, sdk).performSyncRefreshTokenRequest();
-                                sdk.persistAuthState(context, liTokenResponse);
-
-                                request = request.newBuilder().removeHeader(LiAuthConstants.AUTHORIZATION).build();
-                                request = request.newBuilder()
-                                        .addHeader(LiAuthConstants.AUTHORIZATION, LiAuthConstants.BEARER + sdk.getAuthToken())
-                                        .build();
+                            JsonObject data = new Gson().fromJson(responseStr, JsonObject.class);
+                            if (data != null && data.has("statusCode")) {
+                                httpCode = data.get("statusCode").getAsInt();
                             }
-                        } catch (LiRestResponseException e) {
-                            Log.e(LOG_TAG, "Error making rest call for refresh token", e);
+                        } catch (JsonSyntaxException ex) {
+                            Log.e(LI_LOG_TAG, "wrong json, not able to parse " + ex.getMessage());
                         }
-                    }
 
-                    proceed = true;
+                        switch (httpCode) {
+                            //Not including 3XX codes as Lia doesn't handle re-directions
+
+                            //The below auth error codes needs to check refresh tokens before retry.
+                            case HTTP_CODE_UNAUTHORIZED:
+                                //{@link HttpURLConnection.HTTP_UNAUTHORIZED} 401 - Unauthorized access, because of authentication.
+                            case HTTP_CODE_FORBIDDEN: {
+                                //{@link HttpURLConnection.HTTP_FORBIDDEN} 403 - Forbidden access, because of authentication again.
+
+                                try {
+                                    Context context = this.context.get();
+                                    if (context != null) {
+                                        LiTokenResponse liTokenResponse = new LiAuthServiceImpl(context, sdk).performSyncRefreshTokenRequest();
+                                        sdk.persistAuthState(context, liTokenResponse);
+
+                                        request = request.newBuilder().removeHeader(LiAuthConstants.AUTHORIZATION).build();
+                                        request = request.newBuilder()
+                                                .addHeader(LiAuthConstants.AUTHORIZATION, LiAuthConstants.BEARER + sdk.getAuthToken())
+                                                .build();
+                                        proceed = true;
+                                    }
+                                } catch (LiRestResponseException e) {
+                                    Log.e(LOG_TAG, "Error making rest call for refresh token", e);
+                                }
+                                break;
+                            }
+
+                            //As described under https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+                            //Retries needs to be done for all the selected cases below -
+                            case HttpURLConnection.HTTP_INTERNAL_ERROR:
+                                //{@link HttpURLConnection.HTTP_INTERNAL_ERROR} 500 - Internal server error, this could succeed for unsafe &
+                                // non idempotent calls on retrying.
+                                proceed = !((request.method() + "").equalsIgnoreCase("GET"));
+                                break;
+
+                            case HttpURLConnection.HTTP_CLIENT_TIMEOUT:
+                                //{@link HttpURLConnection.HTTP_CLIENT_TIMEOUT} 408 - Client-Timeout, retry should be made
+                            case HttpURLConnection.HTTP_BAD_GATEWAY:
+                                //{@link HttpURLConnection.HTTP_BAD_GATEWAY} 502 - Bad Gateway, An auxiliary dependency could get solved
+                            case HttpURLConnection.HTTP_UNAVAILABLE:
+                                //{@link HttpURLConnection.HTTP_UNAVAILABLE} 503 - Currently unavailable, this is temporary denial of service
+                            case HttpURLConnection.HTTP_GATEWAY_TIMEOUT:
+                                //{@link HttpURLConnection.HTTP_GATEWAY_TIMEOUT} 504 - Gateway-Timeout, usually dependencies on Auxiliary services
+                                proceed = true;
+                                break;
+
+                            default:
+                                proceed = false;
+                        }
+
+                    } catch (InterruptedException e) {
+                        proceed = false; // operation was incomplete do not proceed
+                        e.printStackTrace();
+                    }
                 }
 
                 if (proceed) {

--- a/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
+++ b/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
@@ -538,7 +538,7 @@ public abstract class LiRestClient {
      */
     private static class RefreshAndRetryInterceptor implements Interceptor {
 
-        private static final int MAX_TRIES = 4; // One actual call + 3 trials
+        private static final int MAX_TRIES = 4; // One actual call + 3 Retries
 
         private WeakReference<Context> context;
         private LiSDKManager sdk;
@@ -555,7 +555,8 @@ public abstract class LiRestClient {
             Response response = null;
 
             while (currentCount < MAX_TRIES
-                    && (response == null || ((response.code() != HTTP_CODE_SUCCESSFUL) && (response.code() != HttpURLConnection.HTTP_CREATED)))) {
+                    && (response == null
+                    || ((response.code() != HTTP_CODE_SUCCESSFUL) && (response.code() != HttpURLConnection.HTTP_CREATED)))) {
                 boolean proceed = false;
 
                 if (response == null) {


### PR DESCRIPTION
This PR contains changes in Retry and Followup logic w.r.t the http response status code-
- It checks only transient failure conditions (408, selective-500, 502, 503 & 504) for retrying
- Refreshing the tokens in cases of 401 & 403 failures
- Failure 3xx conditions are not considered since Lia never encountered them.
- Retrying is done exponentially (2 ^ zero_base_incremental_iteration_index) * 4 times (one normal trial + 3 retries)