### PR TITLE
MOB-414 …

### DIFF
--- a/lia-core/src/main/java/com/lithium/community/android/manager/LiAuthManager.java
+++ b/lia-core/src/main/java/com/lithium/community/android/manager/LiAuthManager.java
@@ -217,7 +217,7 @@ class LiAuthManager {
 
         LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
 
-        preferences.clear(context);
+        preferences.clearAuthState(context);
 
         // For clearing cookies, if the android OS is Lollipop (5.0) and above use new
         // way of using CookieManager else use the deprecate methods for older versions.

--- a/lia-core/src/main/java/com/lithium/community/android/manager/LiSecuredPrefManager.java
+++ b/lia-core/src/main/java/com/lithium/community/android/manager/LiSecuredPrefManager.java
@@ -213,6 +213,20 @@ class LiSecuredPrefManager {
         getSecuredPreferences(context).edit().clear().apply();
     }
 
+    /**
+     * Clears the Authentication state of a user (necessarily a logged out user)
+     * @param context - the Android base context to access preferences
+     */
+    public void clearAuthState(@NonNull Context context) {
+        LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
+        getSecuredPreferences(context)
+                .edit()
+                .putString(LiCoreSDKConstants.LI_AUTH_STATE, null)
+                .putString(LiCoreSDKConstants.LI_DEFAULT_SDK_SETTINGS, null)
+                .apply();
+    }
+
+
     @NonNull
     private String encrypt(@NonNull String input) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
             BadPaddingException, IllegalBlockSizeException {


### PR DESCRIPTION
This PR contains changes needed to get beacon calls working after logging out a logged in user - Previously all saved states including visitor-id which is analogous to an SDK client was also getting cleared when a user log's out. 
'visitor-id' is totally independent of any user's context.
Now, clearing only auth related constants and the ones which are not needed in anonymous browsing.