### PR TITLE
MOB-520 Okhttp has fixed the bug in latest version, making use of that

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ allprojects {
         // App dependencies
         supportLibraryVersion = '27.0.2'
         gsonVersion = '2.8.0'
-        okhttpVersion = '3.4.1'
+        okhttpVersion = '3.11.0'
         firebaseMessagingVersion = '11.8.0'
 
         // Test dependencies

--- a/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
+++ b/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
@@ -175,7 +175,7 @@ public abstract class LiRestClient {
 
         Request request = buildRequest(baseRestRequest);
         OkHttpClient.Builder clientBuilder = getOkHttpClient().newBuilder();
-        clientBuilder.interceptors().add(new RefreshAndRetryInterceptor(baseRestRequest.getContext(), sdkManager));
+        clientBuilder.retryOnConnectionFailure(false).interceptors().add(new RefreshAndRetryInterceptor(baseRestRequest.getContext(), sdkManager));
         Response response = null;
 
         try {
@@ -243,6 +243,7 @@ public abstract class LiRestClient {
     private void enqueueCall(@NonNull final LiBaseRestRequest baseRestRequest, @NonNull final LiAsyncRequestCallback callback) {
         Request request = buildRequest(baseRestRequest);
         OkHttpClient.Builder clientBuilder = getOkHttpClient().newBuilder();
+        clientBuilder.retryOnConnectionFailure(false);
         clientBuilder.interceptors().add(new RefreshAndRetryInterceptor(baseRestRequest.getContext(), sdkManager));
         Call call = clientBuilder.build().newCall(request);
         call.enqueue(new Callback() {


### PR DESCRIPTION
This PR contains changes to deprecate the default retry logic of okhttp and enforcing our retry logic.