### PR TITLE
MOB-521 Few corner cases handled along with a consideration to Retry-After reponse header

### DIFF
--- a/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
+++ b/lia-core/src/main/java/com/lithium/community/android/rest/LiRestClient.java
@@ -584,11 +584,9 @@ public abstract class LiRestClient {
                                     retryDuration = 0;
                                 }
                             } catch (ParseException pe) {
-                                pe.printStackTrace();
                                 try {
                                     retryDuration = Long.parseLong(retryAfter) * 1000; //seconds * milliseconds
                                 } catch (NumberFormatException nfe) {
-                                    nfe.printStackTrace();
                                     retryDuration = 0;
                                 }
                             }
@@ -603,7 +601,6 @@ public abstract class LiRestClient {
                         } catch (IllegalStateException ise) {
                             //This could happen for non-transient failures which are not happening below.
                             //unless retried, this could be read twice (second time on the closed stream) which leads to this exception.
-                            ise.printStackTrace();
                             responseStr = "";
                         }
                         synchronized (this) {
@@ -676,7 +673,6 @@ public abstract class LiRestClient {
 
                     } catch (InterruptedException e) {
                         proceed = false; // operation was incomplete do not proceed
-                        e.printStackTrace();
                     }
                 }
 


### PR DESCRIPTION
This PR contains changes to handle -
* Retry-After header which should be part of the Server response header. Cases with and without it's presence
* Crash in non transient failure cases (like http response code being 402, 500, 404...etc) - the reponse stream was read twice, which was throwing IllegalStateException on reading second time.
