### PR TITLE
MOB-464 Subscriptions

### DIFF
--- a/lia-core/src/main/java/com/lithium/community/android/manager/LiClientManager.java
+++ b/lia-core/src/main/java/com/lithium/community/android/manager/LiClientManager.java
@@ -150,6 +150,27 @@ public class LiClientManager {
     }
 
     /**
+     * Retains a Rest GET client which retrieves all subscriptions by a user to a message
+     * @param params - the client params an instance of
+     * {@link com.lithium.community.android.model.request.LiClientRequestParams.LiUserMessageSusbscriptionRequestParans}
+     * @return - a rest client
+     * @throws LiRestResponseException
+     */
+    public static LiClient getUserMessageSubscriptionsClient(LiClientRequestParams.LiUserMessageSusbscriptionRequestParans params)
+            throws LiRestResponseException {
+        params.validate(Client.LI_USER_MESSAGE_SUBSCRIPTIONS_CLIENT);
+        LiQueryValueReplacer replacer = new LiQueryValueReplacer();
+        replacer.replaceAll("##", params.getMessageId());
+        replacer.replaceAll("&&", params.getUserId());
+        return new LiBaseGetClient(params.getContext(),
+                LiQueryConstant.LI_USER_MESSAGE_SUBSCRIPTIONS_CLIENT_LIQL,
+                LiQueryConstant.LI_USER_MESSAGE_SUBSCRIPTIONS_CLIENT_TYPE,
+                LiQueryConstant.LI_USER_MESSAGE_SUBSCRIPTTION_QUERYSETTINGS_TYPE,
+                LiSubscriptions.class)
+                .setReplacer(replacer);
+    }
+
+    /**
      * Fetches a list of boards for a given category, along with board and category details. Create parameters with
      * {@link LiClientRequestParams.LiCategoryBoardsClientRequestParams}.
      *
@@ -1151,6 +1172,7 @@ public class LiClientManager {
         LI_MESSAGES_BY_BOARD_ID_CLIENT,
         LI_SDK_SETTINGS_CLIENT,
         LI_USER_SUBSCRIPTIONS_CLIENT,
+        LI_USER_MESSAGE_SUBSCRIPTIONS_CLIENT,
         LI_CATEGORY_BOARDS_CLIENT,
         LI_BOARDS_BY_DEPTH_CLIENT,
         LI_REPLIES_CLIENT,

--- a/lia-core/src/main/java/com/lithium/community/android/model/helpers/LiUserContext.java
+++ b/lia-core/src/main/java/com/lithium/community/android/model/helpers/LiUserContext.java
@@ -39,6 +39,9 @@ public class LiUserContext extends LiBaseModelImpl {
     @SerializedName("can_delete")
     private boolean canDelete;
 
+    @SerializedName("is_subscribed")
+    private boolean isSubscribed;
+
     public boolean isCanDelete() {
         return canDelete;
     }
@@ -77,5 +80,13 @@ public class LiUserContext extends LiBaseModelImpl {
 
     public void setRead(Boolean read) {
         this.read = read;
+    }
+
+    public boolean isSubscribed() {
+        return isSubscribed;
+    }
+
+    public void setSubscribed(boolean subscribed) {
+        isSubscribed = subscribed;
     }
 }

--- a/lia-core/src/main/java/com/lithium/community/android/model/request/LiClientRequestParams.java
+++ b/lia-core/src/main/java/com/lithium/community/android/model/request/LiClientRequestParams.java
@@ -126,6 +126,33 @@ public class LiClientRequestParams {
         }
     }
 
+    public static class LiUserMessageSusbscriptionRequestParans extends LiClientRequestParams {
+
+        private final String messageId;
+        private final String userId;
+
+        /**
+         * This is to help process the subscriptions query for a user with respect to a message
+         * @param context - the Android context
+         * @param messageId - the message id
+         * @param userId - the user who has susbcribed
+         */
+        public LiUserMessageSusbscriptionRequestParans(Context context, String messageId, String userId) {
+            super(context);
+            this.messageId = messageId;
+            this.userId = userId;
+            this.client = LiClientManager.Client.LI_USER_MESSAGE_SUBSCRIPTIONS_CLIENT;
+        }
+
+        public String getMessageId() {
+            return messageId;
+        }
+
+        public String getUserId() {
+            return userId;
+        }
+    }
+
     //Request params class for LiUserSubscriptionsClient
     public static class LiUserSubscriptionsClientRequestParams extends LiClientRequestParams {
 

--- a/lia-core/src/main/java/com/lithium/community/android/model/response/LiSubscriptions.java
+++ b/lia-core/src/main/java/com/lithium/community/android/model/response/LiSubscriptions.java
@@ -16,6 +16,7 @@
 
 package com.lithium.community.android.model.response;
 
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import com.lithium.community.android.manager.LiClientManager;
@@ -33,7 +34,7 @@ public class LiSubscriptions extends LiBaseModelImpl implements LiTargetModel {
     @SerializedName("id")
     private Long id;
     @SerializedName("target")
-    private JsonObject targetObject;
+    private LiMessage targetObject;
     @SerializedName("subscriber")
     private LiUser user;
 
@@ -62,26 +63,26 @@ public class LiSubscriptions extends LiBaseModelImpl implements LiTargetModel {
     }
 
     public LiMessage getLiMessage() {
-        if (targetObject.has("type") && targetObject.get("type").getAsString().equals("message")) {
-            return LiClientManager.getRestClient().getGson().fromJson(targetObject.toString(), LiMessage.class);
+        if (targetObject != null) {
+            return targetObject;
         } else {
             return null;
         }
     }
 
     public LiBoard getLiBoard() {
-        if (targetObject.has("type") && targetObject.get("type").getAsString().equals("board")) {
-            return LiClientManager.getRestClient().getGson().fromJson(targetObject.toString(), LiBoard.class);
-        } else {
-            return null;
-        }
+        return null;//subscriptions will not have board
     }
 
-    public JsonObject getTargetObject() {
+    public LiMessage getTargetObject() {
         return targetObject;
     }
 
-    public void setTargetObject(JsonObject targetObject) {
+    public void setTargetObject(LiMessage targetObject) {
         this.targetObject = targetObject;
+    }
+
+    public static LiSubscriptions fromJson(String json) {
+        return new GsonBuilder().create().fromJson(json, LiSubscriptions.class);
     }
 }

--- a/lia-core/src/main/java/com/lithium/community/android/model/response/LiUser.java
+++ b/lia-core/src/main/java/com/lithium/community/android/model/response/LiUser.java
@@ -66,7 +66,8 @@ public class LiUser extends LiBaseModelImpl {
     @SerializedName("last_visit_time")
     private LiDateInstant lastVisitInstant;
 
-    private LiBaseModelImpl.LiString login;
+    @SerializedName("login")
+    private String login;
 
     private Long id;
 
@@ -97,8 +98,7 @@ public class LiUser extends LiBaseModelImpl {
         LiAvatar avatar = LiAvatar.deserialize(jsonObject.getJSONObject(USER_AVATAR));
         user.setAvatar(avatar);
         LiString loginStr = new LiString();
-        loginStr.setValue(jsonObject.getString(USER_LOGIN));
-        user.setLogin(loginStr);
+        user.setLogin(jsonObject.getString(USER_LOGIN));
         user.setHref(jsonObject.getString(USER_HREF));
         user.setProfilePageUrl(jsonObject.getString(USER_VIEW_HREF));
 
@@ -293,15 +293,11 @@ public class LiUser extends LiBaseModelImpl {
         profilePageUrl = url;
     }
 
-    public LiBaseModelImpl.LiString getLoginAsLiString() {
+    public String getLogin() {
         return login;
     }
 
-    public String getLogin() {
-        return login.getValue();
-    }
-
-    public void setLogin(LiBaseModelImpl.LiString login) {
+    public void setLogin(String login) {
         this.login = login;
     }
 
@@ -330,7 +326,7 @@ public class LiUser extends LiBaseModelImpl {
             //Logger we cannot handle null/empty author id
 
             if (login != null) {
-                return login.getValue();
+                return login;
             } else {
                 return null;
             }
@@ -343,7 +339,7 @@ public class LiUser extends LiBaseModelImpl {
         }
 
         if (login != null) {
-            return login.getValue();
+            return login;
         } else {
             return null;
         }
@@ -358,7 +354,7 @@ public class LiUser extends LiBaseModelImpl {
         LiCoreSDKUtils.putIfNotNull(json, USER_ID, String.valueOf(this.id));
         LiCoreSDKUtils.put(json, USER_EMAIL, this.email);
         LiCoreSDKUtils.put(json, USER_AVATAR, this.avatar.serialize());
-        LiCoreSDKUtils.put(json, USER_LOGIN, this.login.getValue());
+        LiCoreSDKUtils.put(json, USER_LOGIN, this.login);
         LiCoreSDKUtils.put(json, USER_HREF, this.href);
         if (!TextUtils.isEmpty(profilePageUrl)) {
             LiCoreSDKUtils.put(json, USER_VIEW_HREF, this.profilePageUrl);
@@ -368,6 +364,6 @@ public class LiUser extends LiBaseModelImpl {
 
     @Override
     public String toString() {
-        return "LiUser{email='" + login.getValue() + "'}";
+        return "LiUser{email='" + login + "'}";
     }
 }

--- a/lia-core/src/main/java/com/lithium/community/android/rest/LiBaseResponse.java
+++ b/lia-core/src/main/java/com/lithium/community/android/rest/LiBaseResponse.java
@@ -38,11 +38,12 @@ import okhttp3.Response;
  * Base response object that encapsulates Lithium community json response
  */
 public class LiBaseResponse {
-    private static final String DATA = "data";
-    private static final String TYPE = "type";
-    private static final String ITEMS = "items";
-    private static final String ITEM = "item";
-    private static final String STATUS = "status";
+    public static final String DATA = "data";
+    public static final String TYPE = "type";
+    public static final String ITEMS = "items";
+    public static final String ITEM = "item";
+    public static final String ID = "id";
+    public static final String STATUS = "status";
     private String status;
     private String message;
     private int code;

--- a/lia-core/src/main/java/com/lithium/community/android/utils/LiQueryConstant.java
+++ b/lia-core/src/main/java/com/lithium/community/android/utils/LiQueryConstant.java
@@ -28,6 +28,8 @@ public class LiQueryConstant {
             = "SELECT id, target.author, target.id, target.subject, target.post_time, target.kudos.sum(weight), "
             + "target.body, target.conversation.style, target.conversation.solved, target.conversation.last_post_time"
             + " FROM subscriptions";
+    public static final String LI_USER_MESSAGE_SUBSCRIPTIONS_CLIENT_LIQL
+            = "SELECT id FROM subscriptions";
     public static final String LI_BROWSE_CLIENT_BASE_LIQL
             = "select id, title, parent.id, parent.title, depth from nodes";
     public static final String LI_CATEGORY_CLIENT_BASE_LIQL
@@ -43,7 +45,7 @@ public class LiQueryConstant {
             + "messages";
     public static final String LI_MESSAGE_CONVERSATION_BASE_LIQL
             = "SELECT id, body, subject, view_href, post_time, kudos.sum(weight), can_accept_solution, is_solution, "
-            + "user_context.kudo, user_context.can_kudo, user_context.can_reply, user_context.can_delete, "
+            + "user_context.kudo, user_context.can_kudo, user_context.can_reply, user_context.can_delete, user_context.is_subscribed, "
             + "user_context.read, author, author.id, author.href, author.email,  author.avatar, author.rank, author"
             + ".login, parent.id, metrics, replies.count(*) FROM messages";
 
@@ -53,6 +55,7 @@ public class LiQueryConstant {
     public static final String LI_REPLY_MESSAGE_TYPE = "message";
     public static final String LI_ARTICLES_CLIENT_TYPE = "message";
     public static final String LI_SUBSCRIPTIONS_CLIENT_TYPE = "subscription";
+    public static final String LI_USER_MESSAGE_SUBSCRIPTIONS_CLIENT_TYPE = "message_user_subscriptions";
     public static final String LI_BROWSE_CLIENT_TYPE = "node";
     public static final String LI_SEARCH_CLIENT_TYPE = "message";
     public static final String LI_MESSAGE_CHILDREN_CLIENT_TYPE = "message";
@@ -70,6 +73,7 @@ public class LiQueryConstant {
     public static final String LI_FLOATED_MESSAGE_CLIENT_TYPE = "floated_message";
     public static final String LI_ARTICLES_QUERYSETTINGS_TYPE = "article";
     public static final String LI_SUBSCRIPTTION_QUERYSETTINGS_TYPE = "subscription";
+    public static final String LI_USER_MESSAGE_SUBSCRIPTTION_QUERYSETTINGS_TYPE = "message_user_subscriptions";
     public static final String LI_BROWSE_QUERYSETTINGS_TYPE = "node";
     public static final String LI_BROWSE_BY_DEPTH_QUERYSETTINGS_TYPE = "node_depth";
     public static final String LI_SEARCH_QUERYSETTINGS_TYPE = "search";

--- a/lia-core/src/main/res/raw/li_default_query_settings.json
+++ b/lia-core/src/main/res/raw/li_default_query_settings.json
@@ -296,5 +296,28 @@
         "operator": "or"
       }
     ]
+  },
+  "message_user_subscriptions":{
+    "liDataSource": "subscriptions",
+    "whereClauses":[
+      {
+        "clause": "equals",
+        "key": "subscriber.id",
+        "value": "'&&'",
+        "operator": "AND"
+      },
+      {
+        "clause": "equals",
+        "key": "target.id",
+        "value": "'##'",
+        "operator": "AND"
+      },
+      {
+        "clause": "equals",
+        "key": "target.type",
+        "value": "'message'",
+        "operator": "AND"
+      }
+    ]
   }
 }

--- a/lia-core/src/test/java/com/lithium/community/android/manager/LiAuthManagerTest.java
+++ b/lia-core/src/test/java/com/lithium/community/android/manager/LiAuthManagerTest.java
@@ -89,9 +89,7 @@ public class LiAuthManagerTest {
         email.setValue(EMAIL);
         liUser.setEmail(email);
 
-        LiBaseModelImpl.LiString login = new LiBaseModelImpl.LiString();
-        login.setValue(LOGIN);
-        liUser.setLogin(login);
+        liUser.setLogin(LOGIN);
         liUser.setHref(HREF);
         liUser.setProfilePageUrl(PROFILE_PAGE_URL);
 

--- a/lia-core/src/test/java/com/lithium/community/android/model/LiUserContextTest.java
+++ b/lia-core/src/test/java/com/lithium/community/android/model/LiUserContextTest.java
@@ -32,18 +32,21 @@ public class LiUserContextTest {
     private final Boolean read = true;
     private final boolean canKudo = true;
     private final boolean canReply = true;
+    private final boolean isSubscribed = true;
+
 
     private LiUserContext liUserContext = new LiUserContext();
-
     @Test
     public void getParamsTest() {
         liUserContext.setKudo(kudo);
         liUserContext.setRead(read);
         liUserContext.setCanKudo(canKudo);
         liUserContext.setCanReply(canReply);
+        liUserContext.setSubscribed(isSubscribed);
         assertEquals(kudo, liUserContext.getKudo());
         assertEquals(read, liUserContext.getRead());
         assertEquals(canKudo, liUserContext.isCanKudo());
         assertEquals(canReply, liUserContext.isCanReply());
+        assertEquals(isSubscribed, liUserContext.isSubscribed());
     }
 }

--- a/lia-core/src/test/java/com/lithium/community/android/model/response/LiSubscriptionsTest.java
+++ b/lia-core/src/test/java/com/lithium/community/android/model/response/LiSubscriptionsTest.java
@@ -31,6 +31,7 @@ import com.lithium.community.android.model.LiBaseModelImpl;
 import com.lithium.community.android.model.response.LiSubscriptions;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Created by shoureya.kant on 12/5/16.
@@ -59,6 +60,9 @@ public class LiSubscriptionsTest {
     @Test
     public void getTargetMessageTest() {
         LiMessage message = new LiMessage();
+        LiBaseModelImpl.LiInt idInt = new LiBaseModelImpl.LiInt();
+        idInt.setValue(id);
+        message.setId(idInt);
         subscriptions.setTargetObject(message);
         assertEquals(id, subscriptions.getLiMessage().getId());
     }
@@ -67,7 +71,7 @@ public class LiSubscriptionsTest {
     public void getTargetBoardTest() {
         LiMessage message = new LiMessage();
         subscriptions.setTargetObject(message);
-        assertEquals(id, Long.valueOf(subscriptions.getLiBoard().getId()));
+        assertNull(subscriptions.getLiBoard());
     }
 
 }

--- a/lia-core/src/test/java/com/lithium/community/android/model/response/LiSubscriptionsTest.java
+++ b/lia-core/src/test/java/com/lithium/community/android/model/response/LiSubscriptionsTest.java
@@ -58,19 +58,15 @@ public class LiSubscriptionsTest {
 
     @Test
     public void getTargetMessageTest() {
-        JsonObject messageObject = new JsonObject();
-        messageObject.addProperty("id", id);
-        messageObject.addProperty("type", "message");
-        subscriptions.setTargetObject(messageObject);
+        LiMessage message = new LiMessage();
+        subscriptions.setTargetObject(message);
         assertEquals(id, subscriptions.getLiMessage().getId());
     }
 
     @Test
     public void getTargetBoardTest() {
-        JsonObject messageObject = new JsonObject();
-        messageObject.addProperty("id", id);
-        messageObject.addProperty("type", "board");
-        subscriptions.setTargetObject(messageObject);
+        LiMessage message = new LiMessage();
+        subscriptions.setTargetObject(message);
         assertEquals(id, Long.valueOf(subscriptions.getLiBoard().getId()));
     }
 

--- a/lia-core/src/test/java/com/lithium/community/android/model/response/LiUserTest.java
+++ b/lia-core/src/test/java/com/lithium/community/android/model/response/LiUserTest.java
@@ -156,13 +156,9 @@ public class LiUserTest {
 
     @Test
     public void getLoginTest() {
-        login = new LiBaseModelImpl.LiString();
-        login.setValue(LI_LOGIN);
-        liUser.setLogin(login);
+        liUser.setLogin(LI_LOGIN);
         assertNotEquals(null, liUser.getLogin());
         assertEquals(LI_LOGIN, liUser.getLogin());
-        assertTrue(liUser.getLoginAsLiString() instanceof LiBaseModelImpl.LiString);
-        assertEquals(LI_LOGIN, liUser.getLoginAsLiString().getValue());
     }
 
     @Test
@@ -225,9 +221,7 @@ public class LiUserTest {
         avatar.setMessage("AVATAR");
         liUser.setAvatarImage(avatarImage);
         liUser.setId(ID);
-        login = new LiBaseModelImpl.LiString();
-        login.setValue(LI_LOGIN);
-        liUser.setLogin(login);
+        liUser.setLogin(LI_LOGIN);
         liUser.setProfilePageUrl(PROFILE_PAGE_URL);
         liUser.setHref(HREF);
         LiBaseModelImpl.LiString email = new LiBaseModelImpl.LiString();
@@ -254,9 +248,7 @@ public class LiUserTest {
         LiUser liUser = new LiUser();
         liUser.setAvatarImage(avatarImage);
         liUser.setId(ID);
-        login = new LiBaseModelImpl.LiString();
-        login.setValue(LI_LOGIN);
-        liUser.setLogin(login);
+        liUser.setLogin(LI_LOGIN);
         liUser.setProfilePageUrl(PROFILE_PAGE_URL);
         liUser.setHref(HREF);
         LiBaseModelImpl.LiString email = new LiBaseModelImpl.LiString();

--- a/lia-ui/src/main/java/com/lithium/community/android/ui/components/adapters/LiConversationAdapter.java
+++ b/lia-ui/src/main/java/com/lithium/community/android/ui/components/adapters/LiConversationAdapter.java
@@ -245,7 +245,6 @@ public class LiConversationAdapter extends LiBaseRecyclerAdapter {
 
                 return true;
             } else if (menuItem.getItemId() == R.id.li_action_subscribe) {
-
                 boolean isSubscribed = item.getUserContext().isSubscribed();
                 if (isSubscribed) {
                     unsubscribe(item, position);

--- a/lia-ui/src/main/java/com/lithium/community/android/ui/components/adapters/LiConversationAdapter.java
+++ b/lia-ui/src/main/java/com/lithium/community/android/ui/components/adapters/LiConversationAdapter.java
@@ -39,20 +39,25 @@ import android.webkit.CookieSyncManager;
 import android.widget.ImageView;
 import android.widget.Toast;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import com.lithium.community.android.api.LiClient;
 import com.lithium.community.android.exception.LiRestResponseException;
 import com.lithium.community.android.manager.LiClientManager;
 import com.lithium.community.android.manager.LiSDKManager;
 import com.lithium.community.android.model.LiBaseModel;
 import com.lithium.community.android.model.helpers.LiKudoMetrics;
+import com.lithium.community.android.model.post.LiSubscriptionPostModel;
 import com.lithium.community.android.model.request.LiClientRequestParams;
 import com.lithium.community.android.model.response.LiMessage;
 import com.lithium.community.android.model.response.LiTargetModel;
+import com.lithium.community.android.model.response.LiUser;
 import com.lithium.community.android.rest.LiAsyncRequestCallback;
 import com.lithium.community.android.rest.LiBaseResponse;
 import com.lithium.community.android.rest.LiBaseRestRequest;
 import com.lithium.community.android.rest.LiClientResponse;
 import com.lithium.community.android.rest.LiDeleteClientResponse;
+import com.lithium.community.android.rest.LiGetClientResponse;
 import com.lithium.community.android.rest.LiPostClientResponse;
 import com.lithium.community.android.ui.R;
 import com.lithium.community.android.ui.components.activities.LiCreateMessageActivity;
@@ -65,6 +70,7 @@ import com.lithium.community.android.ui.components.utils.LiUIUtils;
 import com.lithium.community.android.utils.LiCoreSDKConstants;
 import com.squareup.picasso.Picasso;
 
+import java.net.HttpURLConnection;
 import java.util.List;
 
 
@@ -74,12 +80,18 @@ import java.util.List;
  * This class is responsible for displaying the message thread.
  */
 public class LiConversationAdapter extends LiBaseRecyclerAdapter {
+
+    public interface ActionInProgressListener {
+        void actionInProgress(boolean inProgress);
+    }
+
     private static final int TYPE_ORIGINAL_POST = 0;
     LiConversationFragment fragment;
     private boolean isAcceptedSolutionPresent;
     private int avatarDefaultIcon;
     private int firstDiscussionIdx;
     private String htmlTemplate;
+    private ActionInProgressListener mActionInProgressListener;
 
     public LiConversationAdapter(List<LiBaseModel> items, LiOnMessageRowClickListener listener, Activity activity,
             RecyclerView recyclerView, LiConversationFragment fragment) {
@@ -96,6 +108,10 @@ public class LiConversationAdapter extends LiBaseRecyclerAdapter {
         }
         this.fragment = fragment;
         cookieManager.setAcceptCookie(true);
+    }
+
+    public void setActionInProgressListener(ActionInProgressListener actionInProgressListener) {
+        this.mActionInProgressListener = actionInProgressListener;
     }
 
     @Override
@@ -169,136 +185,318 @@ public class LiConversationAdapter extends LiBaseRecyclerAdapter {
             popup.getMenu().removeItem(R.id.li_action_delete);
         }
 
-        popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
-            @Override
-            public boolean onMenuItemClick(MenuItem menuItem) {
-                if (menuItem.getItemId() == R.id.li_action_report_abuse) {
-                    Bundle bundle = new Bundle();
-                    bundle.putString(LiSDKConstants.REPORT_ABUSE_MESSAGE_ID, item.getId() + "");
-                    bundle.putString(LiSDKConstants.REPORT_ABUSE_AUTHOR_ID, item.getAuthor().getId() + "");
-                    Intent i = new Intent(activity, LiReportAbuseActivity.class);
-                    i.putExtras(bundle);
-                    activity.startActivity(i);
-                    return true;
-                } else if (menuItem.getItemId() == R.id.li_action_mark_read) {
-                    if (item.getUserContext() != null) {
-                        boolean isMarkUnread = false;
-                        if (item.getUserContext() != null && item.getUserContext().getRead()) {
-                            isMarkUnread = true;
-                        }
-
-                        LiClientRequestParams.LiMarkMessageParams params = new LiClientRequestParams.LiMarkMessageParams(activity,
-                                String.valueOf(item.getAuthor().getId()),
-                                String.valueOf(item.getId()), isMarkUnread);
-                        try {
-                            LiClientManager.getMarkMessagePostClient(params).processAsync(new LiAsyncRequestCallback<LiPostClientResponse>() {
-                                @Override
-                                public void onSuccess(LiBaseRestRequest request, LiPostClientResponse response) throws LiRestResponseException {
-                                    if (response.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
-                                        item.getUserContext().setRead(!item.getUserContext().getRead());
-                                        LiUIUtils.showMarkReadSuccessful(activity, item);
-                                    } else {
-                                        LiUIUtils.showMarkReadUnSuccessful(activity, item);
-                                    }
-                                }
-
-                                @Override
-                                public void onError(Exception exception) {
-                                    LiUIUtils.showMarkReadUnSuccessful(activity, item);
-                                }
-                            });
-                        } catch (LiRestResponseException e) {
-                            Log.d(LiSDKConstants.GENERIC_LOG_TAG, e.getMessage());
-                        }
-
-                    }
-                    return true;
-                } else if (menuItem.getItemId() == R.id.li_action_delete) {
-
-                    // Todo: Display 'are you sure' popup, could/should be genericized to util?
-                    DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(final DialogInterface dialog, int which) {
-                            switch (which) {
-                                case DialogInterface.BUTTON_POSITIVE:
-
-                                    LiClientRequestParams.LiMessageDeleteClientRequestParams params;
-                                    params = new LiClientRequestParams.LiMessageDeleteClientRequestParams(activity, String.valueOf(item.getId()));
-
-                                    try {
-                                        LiClientManager.getMessageDeleteClient(params).processAsync(
-                                                new LiAsyncRequestCallback<LiDeleteClientResponse>() {
-                                                    @Override
-                                                    public void onSuccess(LiBaseRestRequest request, LiDeleteClientResponse response) {
-                                                        if (activity == null || fragment == null || !fragment.isAdded()) {
-                                                            return;
-                                                        }
-                                                        LiBaseResponse deleteResponse = response.getResponse();
-                                                        if (deleteResponse.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
-                                                            activity.runOnUiThread(new Runnable() {
-                                                                @Override
-                                                                public void run() {
-                                                                    //if there was only one message in the conversation and delete was successful,
-                                                                    // finish the activity
-                                                                    if (getItems().size() == 1 || position == 0) {
-                                                                        activity.finish();
-                                                                    } else {
-                                                                        fragment.onRefresh();
-                                                                    }
-
-                                                                    Toast.makeText(activity,
-                                                                            R.string.li_action_delete_successful,
-                                                                            Toast.LENGTH_SHORT).show();
-                                                                }
-                                                            });
-                                                        } else {
-                                                            dialog.dismiss();
-                                                            activity.runOnUiThread(new Runnable() {
-                                                                @Override
-                                                                public void run() {
-                                                                    Toast.makeText(activity, R.string.li_action_delete_unsuccessful, Toast.LENGTH_SHORT).show();
-                                                                }
-                                                            });
-                                                        }
-                                                    }
-
-                                                    @Override
-                                                    public void onError(Exception exception) {
-                                                        dialog.dismiss();
-                                                        activity.runOnUiThread(new Runnable() {
-                                                            @Override
-                                                            public void run() {
-                                                                Toast.makeText(activity, R.string.li_action_delete_unsuccessful, Toast.LENGTH_SHORT).show();
-                                                            }
-                                                        });
-                                                    }
-                                                }
-                                        );
-                                    } catch (LiRestResponseException e) {
-                                        Log.d(LiSDKConstants.GENERIC_LOG_TAG, e.getMessage());
-                                    }
-                                    break;
-
-                                case DialogInterface.BUTTON_NEGATIVE:
-                                    dialog.dismiss();
-                                    break;
-                                default:
-                                    break;
-                            }
-                        }
-                    };
-                    AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-                    builder.setMessage(R.string.li_are_you_sure)
-                            .setPositiveButton(R.string.li_yes, dialogClickListener)
-                            .setNegativeButton(R.string.li_no, dialogClickListener).show();
-
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-        });
+        boolean showSubscribe = (position == 0);
+        boolean isSubscribed = item.getUserContext().isSubscribed();
+        popup.getMenu().findItem(R.id.li_action_subscribe).setVisible(showSubscribe);
+        popup.getMenu().findItem(R.id.li_action_subscribe).setTitle(isSubscribed ? R.string.li_unsubscribe : R.string.li_subscribe);
+        popup.setOnMenuItemClickListener(new PopupMenuClickListener(item, getItems().size() == 1 || position == 0, position));
         popup.show();
+    }
+
+    private void actionInProgress(boolean inProgress) {
+        if (mActionInProgressListener != null) {
+            mActionInProgressListener.actionInProgress(inProgress);
+        }
+    }
+
+    private class PopupMenuClickListener implements PopupMenu.OnMenuItemClickListener {
+
+        private final LiMessage item;
+        private final boolean isParentItem;
+        private final int position;
+
+        PopupMenuClickListener(LiMessage item, boolean isParentItem, int position) {
+            this.isParentItem = isParentItem;
+            this.position = position;
+            this.item = item;
+        }
+
+        @Override
+        public boolean onMenuItemClick(MenuItem menuItem) {
+            if (menuItem.getItemId() == R.id.li_action_report_abuse) {
+                openReportAbuse(item);
+                return true;
+            } else if (menuItem.getItemId() == R.id.li_action_mark_read) {
+                markRead(item);
+                return true;
+            } else if (menuItem.getItemId() == R.id.li_action_delete) {
+
+                DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(final DialogInterface dialog, int which) {
+                        switch (which) {
+                            case DialogInterface.BUTTON_POSITIVE:
+                                deleteMessage(item, isParentItem);
+                                dialog.dismiss();
+                                break;
+
+                            case DialogInterface.BUTTON_NEGATIVE:
+                                dialog.dismiss();
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                };
+                AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+                builder.setMessage(R.string.li_are_you_sure)
+                        .setPositiveButton(R.string.li_yes, dialogClickListener)
+                        .setNegativeButton(R.string.li_no, dialogClickListener).show();
+
+                return true;
+            } else if (menuItem.getItemId() == R.id.li_action_subscribe) {
+
+                boolean isSubscribed = item.getUserContext().isSubscribed();
+                if (isSubscribed) {
+                    unsubscribe(item, position);
+                } else {
+                    subscribe(item, position);
+                }
+                return false;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    private void openReportAbuse(LiMessage item) {
+        Bundle bundle = new Bundle();
+        bundle.putString(LiSDKConstants.REPORT_ABUSE_MESSAGE_ID, item.getId() + "");
+        bundle.putString(LiSDKConstants.REPORT_ABUSE_AUTHOR_ID, item.getAuthor().getId() + "");
+        Intent i = new Intent(activity, LiReportAbuseActivity.class);
+        i.putExtras(bundle);
+        activity.startActivity(i);
+    }
+
+    private void markRead(LiMessage item) {
+        if (item.getUserContext() != null) {
+            boolean isMarkUnread = false;
+            if (item.getUserContext() != null && item.getUserContext().getRead()) {
+                isMarkUnread = true;
+            }
+            actionInProgress(true);
+
+            LiClientRequestParams.LiMarkMessageParams params = new LiClientRequestParams.LiMarkMessageParams(activity,
+                    String.valueOf(item.getAuthor().getId()),
+                    String.valueOf(item.getId()), isMarkUnread);
+            try {
+                LiClientManager.getMarkMessagePostClient(params).processAsync(new MarkReadCallback(item));
+            } catch (LiRestResponseException e) {
+                actionInProgress(false);
+                Log.d(LiSDKConstants.GENERIC_LOG_TAG, e.getMessage());
+            }
+
+        }
+    }
+
+    private class MarkReadCallback implements LiAsyncRequestCallback<LiPostClientResponse> {
+
+        private final LiMessage item;
+
+        MarkReadCallback(LiMessage item) {
+            this.item = item;
+        }
+
+        @Override
+        public void onSuccess(LiBaseRestRequest request, LiPostClientResponse response) throws LiRestResponseException {
+            if (response.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
+                item.getUserContext().setRead(!item.getUserContext().getRead());
+                LiUIUtils.showMarkReadSuccessful(activity, item);
+            } else {
+                LiUIUtils.showMarkReadUnSuccessful(activity, item);
+            }
+            actionInProgress(false);
+        }
+
+        @Override
+        public void onError(Exception exception) {
+            actionInProgress(false);
+            LiUIUtils.showMarkReadUnSuccessful(activity, item);
+        }
+    }
+
+    private void deleteMessage(LiMessage item, boolean isParentMessage) {
+        LiClientRequestParams.LiMessageDeleteClientRequestParams params;
+        params = new LiClientRequestParams.LiMessageDeleteClientRequestParams(activity, String.valueOf(item.getId()));
+
+        actionInProgress(true);
+        try {
+            LiClientManager.getMessageDeleteClient(params).processAsync(new DeleteMessageCallack(item, isParentMessage));
+        } catch (LiRestResponseException e) {
+            actionInProgress(false);
+            LiUIUtils.showInAppNotification(activity, R.string.li_action_delete_unsuccessful);
+            Log.d(LiSDKConstants.GENERIC_LOG_TAG, e.getMessage());
+        }
+    }
+
+    private class DeleteMessageCallack implements LiAsyncRequestCallback<LiDeleteClientResponse> {
+
+        private final boolean isParentMessage;
+        private final LiMessage item;
+
+        DeleteMessageCallack(LiMessage item, boolean isParentMessage) {
+            this.isParentMessage = isParentMessage;
+            this.item = item;
+        }
+
+        @Override
+        public void onSuccess(LiBaseRestRequest request, LiDeleteClientResponse response) {
+            if (activity == null || fragment == null || !fragment.isAdded()) {
+                return;
+            }
+            LiBaseResponse deleteResponse = response.getResponse();
+            actionInProgress(false);
+
+            if (deleteResponse.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
+                activity.runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        //if there was only one message in the conversation and delete was successful,
+                        // finish the activity
+                        if (isParentMessage) {
+                            activity.finish();
+                        } else {
+                            fragment.onRefresh();
+                        }
+
+                        LiUIUtils.showInAppNotification(activity, R.string.li_action_delete_successful);
+                    }
+                });
+            } else {
+                LiUIUtils.showInAppNotification(activity, R.string.li_action_delete_unsuccessful);
+            }
+        }
+
+        @Override
+        public void onError(Exception exception) {
+            LiUIUtils.showInAppNotification(activity, R.string.li_action_delete_unsuccessful);
+            actionInProgress(false);
+            Log.d(LiSDKConstants.GENERIC_LOG_TAG, exception.getMessage());
+        }
+    }
+
+    private void subscribe(LiMessage item, int position) {
+        actionInProgress(true);
+
+        LiSubscriptionPostModel.Target target = new LiSubscriptionPostModel.MessageTarget(item.getId() + "");
+        LiClientRequestParams.LiPostSubscriptionParams params = new LiClientRequestParams.LiPostSubscriptionParams(activity, target);
+        try {
+            LiClient liClient = LiClientManager.getSubscriptionPostClient(params);
+            liClient.processAsync(new MessageSubscriptionCallback(position, item));
+        } catch (LiRestResponseException lrre) {
+            actionInProgress(false);
+            LiUIUtils.showInAppNotification(activity, R.string.li_action_subscribe_unsuccessful);
+            Log.d(LiSDKConstants.GENERIC_LOG_TAG, lrre.getMessage());
+        }
+    }
+
+    private class MessageSubscriptionCallback implements LiAsyncRequestCallback<LiPostClientResponse> {
+        private final int position;
+        private final LiMessage item;
+
+        MessageSubscriptionCallback(int position, LiMessage item) {
+            this.position = position;
+            this.item = item;
+        }
+
+        @Override
+        public void onSuccess(LiBaseRestRequest request, LiPostClientResponse response) throws LiRestResponseException {
+            actionInProgress(false);
+
+            if (response.getHttpCode() == HttpURLConnection.HTTP_OK || response.getHttpCode() == HttpURLConnection.HTTP_CREATED) {
+                LiUIUtils.showInAppNotification(activity, R.string.li_action_subscribe_successful);
+                activity.runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        item.getUserContext().setSubscribed(true);
+                        notifyItemChanged(position);
+                    }
+                });
+            } else {
+                LiUIUtils.showInAppNotification(activity, R.string.li_action_subscribe_unsuccessful);
+            }
+        }
+
+        @Override
+        public void onError(Exception exception) {
+            LiUIUtils.showInAppNotification(activity, R.string.li_action_subscribe_unsuccessful);
+            actionInProgress(false);
+            Log.d(LiSDKConstants.GENERIC_LOG_TAG, exception.getMessage());
+        }
+    }
+
+    private void unsubscribe(LiMessage item, int position) {
+        actionInProgress(true);
+
+        LiUser user = LiSDKManager.getInstance().getLoggedInUser();
+        LiClientRequestParams.LiUserMessageSusbscriptionRequestParans params
+                = new LiClientRequestParams.LiUserMessageSusbscriptionRequestParans(activity, "" + item.getId(), "" + user.getId());
+        try {
+            LiClient client = LiClientManager.getUserMessageSubscriptionsClient(params);
+            client.processAsync(new MessageUserSubscriptionsCallback());
+        } catch (LiRestResponseException lrre) {
+            actionInProgress(false);
+            LiUIUtils.showInAppNotification(activity, R.string.li_action_unsubscribe_unsuccessful);
+            Log.d(LiSDKConstants.GENERIC_LOG_TAG, lrre.getMessage());
+        }
+    }
+
+    public class MessageUserSubscriptionsCallback implements LiAsyncRequestCallback<LiGetClientResponse> {
+
+        @Override
+        public void onSuccess(LiBaseRestRequest request, LiGetClientResponse response) throws LiRestResponseException {
+            if (response.getHttpCode() == HttpURLConnection.HTTP_OK || response.getHttpCode() == HttpURLConnection.HTTP_CREATED) {
+                JsonObject responseObject = response.getJsonObject();
+                if (!responseObject.has("data")) {
+                    LiUIUtils.showInAppNotification(activity, R.string.li_action_unsubscribe_unsuccessful);
+                    actionInProgress(false);
+                    return;
+                }
+                JsonObject dataObject = responseObject.getAsJsonObject("data");
+                if (!dataObject.has("items")) {
+                    LiUIUtils.showInAppNotification(activity, R.string.li_action_unsubscribe_unsuccessful);
+                    actionInProgress(false);
+                    return;
+                }
+                JsonArray array = dataObject.getAsJsonArray("items");
+                if (array == null || array.size() != 1) {
+                    LiUIUtils.showInAppNotification(activity, R.string.li_action_unsubscribe_unsuccessful);
+                    actionInProgress(false);
+                    return;
+                }
+                String id = array.get(0).getAsJsonObject().get("id").getAsString();
+                LiClientRequestParams.LiDeleteSubscriptionParams deleteSubscriptionParams = new LiClientRequestParams.LiDeleteSubscriptionParams(activity, id);
+                LiClient client = LiClientManager.getSubscriptionDeleteClient(deleteSubscriptionParams);
+                client.processAsync(new MessageSubscriptionDeleteCallback());
+            }
+        }
+
+        @Override
+        public void onError(Exception exception) {
+            actionInProgress(false);
+            LiUIUtils.showInAppNotification(activity, R.string.li_action_unsubscribe_unsuccessful);
+            Log.d(LiSDKConstants.GENERIC_LOG_TAG, exception.getMessage());
+        }
+    }
+
+    private class MessageSubscriptionDeleteCallback implements LiAsyncRequestCallback<LiDeleteClientResponse> {
+
+        @Override
+        public void onSuccess(LiBaseRestRequest request, LiDeleteClientResponse response) throws LiRestResponseException {
+            if (response.getHttpCode() == HttpURLConnection.HTTP_OK || response.getHttpCode() == HttpURLConnection.HTTP_CREATED) {
+                LiUIUtils.showInAppNotification(activity, R.string.li_action_unsubscribe_successful);
+            } else {
+                LiUIUtils.showInAppNotification(activity, R.string.li_action_unsubscribe_unsuccessful);
+            }
+            actionInProgress(false);
+        }
+
+        @Override
+        public void onError(Exception exception) {
+            actionInProgress(false);
+            LiUIUtils.showInAppNotification(activity, R.string.li_action_unsubscribe_unsuccessful);
+            Log.d(LiSDKConstants.GENERIC_LOG_TAG, exception.getMessage());
+        }
     }
 
     /**
@@ -683,8 +881,8 @@ public class LiConversationAdapter extends LiBaseRecyclerAdapter {
         String avatarImageUrl = null;
         String loginName = null;
         if (item.getAuthor() != null) {
-            if (item.getAuthor().getLoginAsLiString() != null) {
-                loginName = item.getAuthor().getLoginAsLiString().getValue();
+            if (item.getAuthor().getLogin() != null) {
+                loginName = item.getAuthor().getLogin();
             }
 
             if (item.getAuthor() != null

--- a/lia-ui/src/main/java/com/lithium/community/android/ui/components/adapters/LiCreateMessageAdapter.java
+++ b/lia-ui/src/main/java/com/lithium/community/android/ui/components/adapters/LiCreateMessageAdapter.java
@@ -110,8 +110,8 @@ public class LiCreateMessageAdapter extends RecyclerView.Adapter<LiViewHolder> {
         String avatarImageUrl = null;
         String loginName = null;
         if (item.getAuthor() != null) {
-            if (item.getAuthor().getLoginAsLiString() != null) {
-                loginName = item.getAuthor().getLoginAsLiString().getValue();
+            if (item.getAuthor().getLogin() != null) {
+                loginName = item.getAuthor().getLogin();
             }
 
             if (item.getAuthor() != null
@@ -182,8 +182,8 @@ public class LiCreateMessageAdapter extends RecyclerView.Adapter<LiViewHolder> {
                 liAuthoringViewHolder.inReplyToContainer.setVisibility(View.VISIBLE);
                 String loginName = null;
                 if (liMessage.getAuthor() != null) {
-                    if (liMessage.getAuthor().getLoginAsLiString() != null) {
-                        loginName = liMessage.getAuthor().getLoginAsLiString().getValue();
+                    if (liMessage.getAuthor().getLogin() != null) {
+                        loginName = liMessage.getAuthor().getLogin();
                     }
                 }
                 String inReplyTo = String.format(activity.getString(R.string.li_in_reply_to_text), loginName);

--- a/lia-ui/src/main/java/com/lithium/community/android/ui/components/fragments/LiBaseFragment.java
+++ b/lia-ui/src/main/java/com/lithium/community/android/ui/components/fragments/LiBaseFragment.java
@@ -167,6 +167,12 @@ public abstract class LiBaseFragment extends DialogFragment
         }
     }
 
+    protected void setRefreshing(boolean refreshing) {
+        if (swipeable != null) {
+            swipeable.setRefreshing(refreshing);
+        }
+    }
+
     /**
      * Check if the network is available or not, If the user is logged in or not.
      * If not then refresh the UI else go ahead and fetch the data from server

--- a/lia-ui/src/main/java/com/lithium/community/android/ui/components/fragments/LiConversationFragment.java
+++ b/lia-ui/src/main/java/com/lithium/community/android/ui/components/fragments/LiConversationFragment.java
@@ -61,7 +61,7 @@ import java.util.ArrayList;
  * <p>
  * {@link LiSDKConstants#SELECTED_MESSAGE_ID} It requires a message/topic id to display the conversation.
  */
-public class LiConversationFragment extends LiBaseFragment {
+public class LiConversationFragment extends LiBaseFragment implements LiConversationAdapter.ActionInProgressListener {
     LiMessage originalMessage;
     private Long selectedMessageId;
     private boolean updateTitle;
@@ -81,6 +81,7 @@ public class LiConversationFragment extends LiBaseFragment {
     protected RecyclerView.Adapter getAdapter() {
         if (adapter == null) {
             adapter = new LiConversationAdapter(response, mListener, getActivity(), recyclerView, this);
+            ((LiConversationAdapter)adapter).setActionInProgressListener(this);
         }
         return adapter;
     }
@@ -331,5 +332,24 @@ public class LiConversationFragment extends LiBaseFragment {
         }
 
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void actionInProgress(boolean inProgress) {
+        getActivity().runOnUiThread(new UiAction(inProgress));
+    }
+
+    private class UiAction implements Runnable {
+
+        private final boolean inProgress;
+
+        private UiAction(boolean inProgress) {
+            this.inProgress = inProgress;
+        }
+
+        @Override
+        public void run() {
+            setRefreshing(inProgress);
+        }
     }
 }

--- a/lia-ui/src/main/java/com/lithium/community/android/ui/components/utils/LiUIUtils.java
+++ b/lia-ui/src/main/java/com/lithium/community/android/ui/components/utils/LiUIUtils.java
@@ -215,7 +215,4 @@ public class LiUIUtils {
         }
     }
 
-    public static void showDeleteMessageStatus(Activity activity, boolean successful){
-
-    }
 }

--- a/lia-ui/src/main/java/com/lithium/community/android/ui/components/utils/LiUIUtils.java
+++ b/lia-ui/src/main/java/com/lithium/community/android/ui/components/utils/LiUIUtils.java
@@ -215,4 +215,7 @@ public class LiUIUtils {
         }
     }
 
+    public static void showDeleteMessageStatus(Activity activity, boolean successful){
+
+    }
 }

--- a/lia-ui/src/main/res/menu/li_conversation_action_menu.xml
+++ b/lia-ui/src/main/res/menu/li_conversation_action_menu.xml
@@ -32,4 +32,9 @@
         android:orderInCategory="99"
         app:showAsAction="never"
         android:title="@string/li_report_inappropriate_content"/>
+    <item
+        android:id="@+id/li_action_subscribe"
+        android:orderInCategory="100"
+        app:showAsAction="never"
+        android:title="@string/li_subscribe"/>
 </menu>

--- a/lia-ui/src/main/res/values/strings.xml
+++ b/lia-ui/src/main/res/values/strings.xml
@@ -123,4 +123,10 @@
     <string name="li_action_delete_successful">Successfully deleted.</string>
     <string name="li_reply_subject_prepender">Re:&#160;</string>
     <string name="li_select_image_source">Select Image Source</string>
+    <string name="li_subscribe">Subscribe</string>
+    <string name="li_unsubscribe">Unsubscribe</string>
+    <string name="li_action_subscribe_successful">Subscribed Successfully</string>
+    <string name="li_action_subscribe_unsuccessful">Could not Subscribe to the message. Please try again later</string>
+    <string name="li_action_unsubscribe_successful">Un-Subscribed Successfully</string>
+    <string name="li_action_unsubscribe_unsuccessful">Could not Un-Subscribe from the message. Please try again later</string>
 </resources>


### PR DESCRIPTION
This PR contains Changes 

- Enabling subscribe/unsubscribe options in Android UI SDK
- Updating UI when actions like Delete/(Un)Mark-Read/(Un)Subscribe actions are taking place in the background.
Also,
- 'DELETE' Subscriptions referred as Unsubscribe - needs a subscription-id of a particular message, which is not available through current LiQL-queries. Hence, added a new LiQL query which 'GET's subscription id of a post through "SELECT id from subscriptions where target.id = '\<post-id\>' AND target.type = 'message' and subscriber.id = '\<user-id\>'" LiQL query. Here post-id and user-id are respectively message's id and the currently logged in user's id, and they are variables.